### PR TITLE
Add Create Schedule Feature

### DIFF
--- a/back/src/schedule/modules/post_schedule/post_schedule_controller.ts
+++ b/back/src/schedule/modules/post_schedule/post_schedule_controller.ts
@@ -1,0 +1,52 @@
+import { ScheduleJsonProps } from '../../../shared/domain/entities/schedule'
+import { HttpRequest } from '../../../shared/domain/helpers/http/http_request'
+import {
+  Error,
+  HttpResponse
+} from '../../../shared/domain/helpers/http/http_response'
+import { PostScheduleUsecase } from './post_schedule_usecase'
+import { PostScheduleRequest } from './protocols'
+
+interface PostScheduleControllerProps {
+  usecase: PostScheduleUsecase
+  call(
+    req: HttpRequest<PostScheduleRequest>
+  ): Promise<HttpResponse<ScheduleJsonProps> | HttpResponse<Error>>
+}
+
+export class PostScheduleController implements PostScheduleControllerProps {
+  constructor(public usecase: PostScheduleUsecase) {
+    this.usecase = usecase
+  }
+
+  async call(req: HttpRequest<PostScheduleRequest>) {
+    if (!req.data?.eventId && !req.data?.name && !req.data?.time) {
+      return HttpResponse.badRequest('missing body')
+    }
+
+    const { eventId, name, time } = req.data
+
+    if (!eventId) {
+      return HttpResponse.badRequest('missing eventId')
+    }
+
+    if (!name) {
+      return HttpResponse.badRequest('missing name')
+    }
+
+    if (!time) {
+      return HttpResponse.badRequest('missing time')
+    }
+
+    try {
+      const schedule = await this.usecase.call(eventId, time, name)
+
+      return HttpResponse.created<ScheduleJsonProps>(
+        'schedule created',
+        schedule.toJson()
+      )
+    } catch (error: any) {
+      return HttpResponse.internalServerError(error.message)
+    }
+  }
+}

--- a/back/src/schedule/modules/post_schedule/post_schedule_presenter.ts
+++ b/back/src/schedule/modules/post_schedule/post_schedule_presenter.ts
@@ -1,0 +1,44 @@
+import { config } from 'dotenv'
+
+import { ScheduleJsonProps } from '../../../shared/domain/entities/schedule'
+import { HttpRequest } from '../../../shared/domain/helpers/http/http_request'
+import {
+  Error,
+  HttpResponse
+} from '../../../shared/domain/helpers/http/http_response'
+import { ScheduleRepositoryHttp } from '../../shared/infra/repos/schedule_repository_http'
+import { ScheduleRepositoryInterface } from '../../shared/infra/repos/schedule_repository_interface'
+import { ScheduleRepositoryMock } from '../../shared/infra/repos/schedule_repository_mock'
+import { PostScheduleController } from './post_schedule_controller'
+import { PostScheduleUsecase } from './post_schedule_usecase'
+import { PostScheduleRequest } from './protocols'
+
+config()
+
+export interface PostSchedulePresenterProps {
+  repo: ScheduleRepositoryInterface
+  usecase: PostScheduleUsecase
+  controller: PostScheduleController
+  call(
+    req: HttpRequest<PostScheduleRequest>
+  ): Promise<HttpResponse<ScheduleJsonProps> | HttpResponse<Error>>
+}
+
+const stage = process.env.STAGE || 'test'
+
+export class PostSchedulePresenter implements PostSchedulePresenterProps {
+  repo: ScheduleRepositoryInterface
+  usecase: PostScheduleUsecase
+  controller: PostScheduleController
+
+  constructor() {
+    this.repo =
+      stage === 'test' ? new ScheduleRepositoryMock() : new ScheduleRepositoryHttp()
+    this.usecase = new PostScheduleUsecase(this.repo)
+    this.controller = new PostScheduleController(this.usecase)
+  }
+
+  async call(req: HttpRequest<PostScheduleRequest>) {
+    return await this.controller.call(req)
+  }
+}

--- a/back/src/schedule/modules/post_schedule/post_schedule_usecase.ts
+++ b/back/src/schedule/modules/post_schedule/post_schedule_usecase.ts
@@ -1,0 +1,26 @@
+import { Schedule } from '../../../shared/domain/entities/schedule'
+import { ScheduleRepositoryInterface } from '../../shared/infra/repos/schedule_repository_interface'
+import { v4 as uuidv4 } from 'uuid'
+
+export interface PostScheduleUsecaseProps {
+  repo: ScheduleRepositoryInterface
+  call(eventId: string, time: number, name: string): Promise<Schedule>
+}
+
+export class PostScheduleUsecase implements PostScheduleUsecaseProps {
+  constructor(public repo: ScheduleRepositoryInterface) {
+    this.repo = repo
+  }
+  
+  async call(eventId: string, time: number, name: string) {
+
+    // TODO: Verify if event exists
+    
+    return await this.repo.createSchedule({
+      id: uuidv4(),
+      eventId,
+      time,
+      name
+    })
+  }
+}

--- a/back/src/schedule/modules/post_schedule/protocols.ts
+++ b/back/src/schedule/modules/post_schedule/protocols.ts
@@ -1,0 +1,13 @@
+import { ScheduleJsonProps } from '../../../shared/domain/entities/schedule'
+
+export type PostScheduleRequest = {
+  eventId: string
+  time: number
+  name: string
+}
+
+export type PostScheduleResponse = {
+  status: number
+  message: string
+  schedule?: ScheduleJsonProps
+}

--- a/back/src/schedule/routes/schedule.routes.ts
+++ b/back/src/schedule/routes/schedule.routes.ts
@@ -2,12 +2,22 @@ import { Router } from 'express'
 
 import { HttpRequest } from '../../shared/domain/helpers/http/http_request'
 import { GetSchedulesByEventPresenter } from '../modules/get_schedules_by_event/get_schedules_by_event_presenter'
+import { PostSchedulePresenter } from '../modules/post_schedule/post_schedule_presenter'
 
 export const scheduleRouter = Router()
 
 scheduleRouter.get('/eventId=:eventId', async (req, res) => {
   const request = new HttpRequest('get', req.params)
   const presenter = new GetSchedulesByEventPresenter()
+  const response = await presenter.call(request)
+  res
+    .status(response.status)
+    .json({ message: response.message, data: response.data })
+})
+
+scheduleRouter.post('/eventId=:eventId', async (req, res) => {
+  const request = new HttpRequest('post', req.body)
+  const presenter = new PostSchedulePresenter()
   const response = await presenter.call(request)
   res
     .status(response.status)

--- a/back/src/schedule/shared/infra/repos/schedule_repository_http.ts
+++ b/back/src/schedule/shared/infra/repos/schedule_repository_http.ts
@@ -7,7 +7,12 @@ export class ScheduleRepositoryHttp implements ScheduleRepositoryInterface {
   getSchedulesByEventId(eventId: string): Promise<Schedule[]> {
     throw new Error('Method not implemented.')
   }
-  createSchedule(schedule: { eventId: string; time: number; name: string }): Promise<Schedule> {
+  createSchedule(schedule: {
+    id: string
+    eventId: string
+    time: number
+    name: string
+  }): Promise<Schedule> {
     throw new Error('Method not implemented.')
   }
   deleteSchedule(scheduleId: string): Promise<Schedule> {

--- a/back/src/schedule/shared/infra/repos/schedule_repository_interface.ts
+++ b/back/src/schedule/shared/infra/repos/schedule_repository_interface.ts
@@ -3,6 +3,7 @@ import { Schedule } from '../../../../shared/domain/entities/schedule'
 export interface ScheduleRepositoryInterface {
   getSchedulesByEventId(eventId: string): Promise<Schedule[]>
   createSchedule(schedule: {
+    id: string
     eventId: string
     time: number
     name: string

--- a/back/src/schedule/shared/infra/repos/schedule_repository_mock.ts
+++ b/back/src/schedule/shared/infra/repos/schedule_repository_mock.ts
@@ -2,7 +2,6 @@ import { Event } from '../../../../shared/domain/entities/event'
 import { Schedule } from '../../../../shared/domain/entities/schedule'
 import { NotFoundError } from '../../../../shared/domain/helpers/errors/not_found'
 import { ScheduleRepositoryInterface } from './schedule_repository_interface'
-import { v4 as uuidv4 } from 'uuid'
 
 export class ScheduleRepositoryMock implements ScheduleRepositoryInterface {
   static schedules = [
@@ -66,12 +65,13 @@ export class ScheduleRepositoryMock implements ScheduleRepositoryInterface {
   }
 
   createSchedule(schedule: {
+    id: string
     eventId: string
     time: number
     name: string
   }): Promise<Schedule> {
     const newSchedule = new Schedule(
-      uuidv4(),
+      schedule.id,
       schedule.eventId,
       schedule.time,
       schedule.name

--- a/back/tests/schedule/modules/post_schedule/post_schedule_controller.test.ts
+++ b/back/tests/schedule/modules/post_schedule/post_schedule_controller.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, test } from 'vitest'
+
+import { HttpRequest } from '../../../../src/shared/domain/helpers/http/http_request'
+import { HTTP_STATUS_CODE } from '../../../../src/shared/domain/helpers/http/http_status_code'
+import { ScheduleRepositoryMock } from '../../../../src/schedule/shared/infra/repos/schedule_repository_mock'
+import { PostScheduleUsecase } from '../../../../src/schedule/modules/post_schedule/post_schedule_usecase'
+import { PostScheduleController } from '../../../../src/schedule/modules/post_schedule/post_schedule_controller'
+
+test('post schedule controller created', async () => {
+  const repo = new ScheduleRepositoryMock()
+  const usecase = new PostScheduleUsecase(repo)
+  const controller = new PostScheduleController(usecase)
+
+  const request = new HttpRequest('post', {
+    eventId: '1',
+    time: 1632940200000,
+    name: 'Soller'
+  })
+
+  const response = await controller.call(request)
+  expect(response.status).toBe(HTTP_STATUS_CODE.CREATED)
+  expect(response.message).toBe('schedule created')
+  expect(response.data).toBeInstanceOf(Object)
+})
+
+describe('post schedule controller body', () => {
+  it('should return BAD REQUEST if body is missing', async () => {
+    const repo = new ScheduleRepositoryMock()
+    const usecase = new PostScheduleUsecase(repo)
+    const controller = new PostScheduleController(usecase)
+    const request = new HttpRequest('post', {} as any)
+    const response = await controller.call(request)
+    expect(response.status).toBe(HTTP_STATUS_CODE.BAD_REQUEST)
+    expect(response.message).toBe('missing body')
+    expect(response.data).toBe(undefined)
+  })
+
+  it('should return BAD REQUEST if eventId is missing', async () => {
+    const repo = new ScheduleRepositoryMock()
+    const usecase = new PostScheduleUsecase(repo)
+    const controller = new PostScheduleController(usecase)
+    const request = new HttpRequest('post', {
+      eventId: '',
+      time: 1632940200000,
+      name: 'Soller'
+    })
+    const response = await controller.call(request)
+    expect(response.status).toBe(HTTP_STATUS_CODE.BAD_REQUEST)
+    expect(response.message).toBe('missing eventId')
+    expect(response.data).toBe(undefined)
+  })
+
+  it('should return BAD REQUEST if name is missing', async () => {
+    const repo = new ScheduleRepositoryMock()
+    const usecase = new PostScheduleUsecase(repo)
+    const controller = new PostScheduleController(usecase)
+    const request = new HttpRequest('post', {
+      eventId: '1',
+      time: 1632940200000,
+      name: ''
+    })
+    const response = await controller.call(request)
+    expect(response.status).toBe(HTTP_STATUS_CODE.BAD_REQUEST)
+    expect(response.message).toBe('missing name')
+    expect(response.data).toBe(undefined)
+  })
+
+  it('should return BAD REQUEST if time is missing', async () => {
+    const repo = new ScheduleRepositoryMock()
+    const usecase = new PostScheduleUsecase(repo)
+    const controller = new PostScheduleController(usecase)
+    const request = new HttpRequest('post', {
+      eventId: '1',
+      time: 0,
+      name: 'Soller'
+    })
+    const response = await controller.call(request)
+    expect(response.status).toBe(HTTP_STATUS_CODE.BAD_REQUEST)
+    expect(response.message).toBe('missing time')
+    expect(response.data).toBe(undefined)
+  })
+})

--- a/back/tests/schedule/modules/post_schedule/post_schedule_presenter.test.ts
+++ b/back/tests/schedule/modules/post_schedule/post_schedule_presenter.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, test } from 'vitest'
+
+import { HttpRequest } from '../../../../src/shared/domain/helpers/http/http_request'
+import { HTTP_STATUS_CODE } from '../../../../src/shared/domain/helpers/http/http_status_code'
+import { ScheduleRepositoryMock } from '../../../../src/schedule/shared/infra/repos/schedule_repository_mock'
+import { PostSchedulePresenter } from '../../../../src/schedule/modules/post_schedule/post_schedule_presenter'
+
+test('post schedule presenter created', async () => {
+  const repo = new ScheduleRepositoryMock()
+  const presenter = new PostSchedulePresenter()
+  const request = new HttpRequest('post', {
+    eventId: '1',
+    time: 1632940200000,
+    name: 'Soller'
+  })
+  const response = await presenter.call(request)
+
+  const scheduleExpect = {
+    // cant use id because it is generated
+    event_id: '1',
+    time: 1632940200000,
+    name: 'Soller'
+  }
+  expect(response.status).toBe(HTTP_STATUS_CODE.CREATED)
+  expect(response.message).toBe('schedule created')
+  expect(response.data).contain(scheduleExpect)
+})

--- a/back/tests/schedule/modules/post_schedule/post_schedule_usecase.test.ts
+++ b/back/tests/schedule/modules/post_schedule/post_schedule_usecase.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from 'vitest'
+import { ScheduleRepositoryMock } from '../../../../src/schedule/shared/infra/repos/schedule_repository_mock'
+import { PostScheduleUsecase } from '../../../../src/schedule/modules/post_schedule/post_schedule_usecase'
+import { Schedule } from '../../../../src/shared/domain/entities/schedule'
+
+test('post schedule usecase created', async () => {
+  const repo = new ScheduleRepositoryMock()
+  const usecase = new PostScheduleUsecase(repo)
+
+  const schedule = await usecase.call(
+    '1',
+    1632940200000, // 1632940200000 = 29/09/2021 18:30:00 (GMT-3)
+    'Soller'
+  )
+
+  expect(schedule).toBeInstanceOf(Schedule)
+  expect(schedule?.id.length).toBe(36)
+  expect(schedule?.eventId).toBe('1')
+  expect(schedule?.time).toBe(1632940200000)
+  expect(schedule?.name).toBe('Soller')
+})

--- a/back/tests/schedule/shared/infra/repos/schedule_repository_mock.test.ts
+++ b/back/tests/schedule/shared/infra/repos/schedule_repository_mock.test.ts
@@ -12,6 +12,7 @@ test('test create schedule', async () => {
   const repo = new ScheduleRepositoryMock()
   const lenBefore: number = ScheduleRepositoryMock.schedules.length
   const schedule = await repo.createSchedule({
+    id: '3bdea174-7ae8-474b-a649-93be4620bba6',
     eventId: '2',
     time: 1632942000000,
     name: 'João'


### PR DESCRIPTION
Adiciona a funcionalidade de Post (Create) Schedule com todos os testes necessários.

Funcionamento:
![image](https://github.com/4-ANO-COMP-IMT/ac2/assets/81604963/47d4e95d-b763-44d1-8d20-b8b985dad170)

![image](https://github.com/4-ANO-COMP-IMT/ac2/assets/81604963/cc4cd22c-1062-4af0-8d80-05f447cef271)

Alguns problemas:

- Ainda não possui a verificação se evento existe
- Não verifica o tipo, apesar de tratar se a informação é recebida ou não
- Entender melhor funcionalidade de get (por nome? por id? precisamos de definições)