### PR TITLE
chore(entrega02): implementa o segundo microsservico e cria o esqueleto do front end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
         with:
           node-version: "20"
       - name: Install dependencies
-        run: npm install
+        run: |
+          cd back
+          npm install
       - name: Run tests
         run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: Test CI
+
+on:
+  push:
+
+jobs:
+  TestBackend:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "20"
+      - name: Install dependencies
+        run: npm install
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,6 @@ jobs:
           cd back
           npm install
       - name: Run tests
-        run: npm test
+        run: |
+          cd back
+          npm test

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 */lerna-debug.log*
 */.pnpm-debug.log*
 */package-lock.json
+*/pnpm-lock.json
 
 # Bower dependency directory (https://bower.io/)
 */bower_components

--- a/back/package.json
+++ b/back/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "uuid": "^9.0.1"
   }
 }

--- a/back/package.json
+++ b/back/package.json
@@ -20,6 +20,7 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/node": "^20.12.7",
+    "@types/uuid": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "^7.10.0",
     "@typescript-eslint/parser": "^7.10.0",
     "eslint": "^8.47.0",

--- a/back/pnpm-lock.yaml
+++ b/back/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@types/uuid':
+        specifier: ^9.0.8
+        version: 9.0.8
       cors:
         specifier: ^2.8.5
         version: 2.8.5
@@ -400,6 +403,9 @@ packages:
 
   '@types/serve-static@1.15.7':
     resolution: {integrity: sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==}
+
+  '@types/uuid@9.0.8':
+    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
   '@typescript-eslint/eslint-plugin@7.10.0':
     resolution: {integrity: sha512-PzCr+a/KAef5ZawX7nbyNwBDtM1HdLIT53aSA2DDlxmxMngZ43O8SIePOeX8H5S+FHXeI6t97mTt/dDdzY4Fyw==}
@@ -1784,6 +1790,8 @@ snapshots:
       '@types/http-errors': 2.0.4
       '@types/node': 20.12.7
       '@types/send': 0.17.4
+
+  '@types/uuid@9.0.8': {}
 
   '@typescript-eslint/eslint-plugin@7.10.0(@typescript-eslint/parser@7.10.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)':
     dependencies:

--- a/back/pnpm-lock.yaml
+++ b/back/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       express:
         specifier: ^4.19.2
         version: 4.19.2
+      uuid:
+        specifier: ^9.0.1
+        version: 9.0.1
     devDependencies:
       '@types/cors':
         specifier: ^2.8.17
@@ -46,8 +49,8 @@ importers:
         specifier: ^12.1.0
         version: 12.1.0(eslint@8.57.0)
       nodemon:
-        specifier: ^3.1.0
-        version: 3.1.0
+        specifier: ^3.1.1
+        version: 3.1.2
       prettier:
         specifier: ^3.2.5
         version: 3.2.5
@@ -1078,8 +1081,8 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
 
-  nodemon@3.1.0:
-    resolution: {integrity: sha512-xqlktYlDMCepBJd43ZQhjWwMw2obW/JRvkrLxq5RCNcuDDX1DbcPT+qT1IlIIdf+DhnWs90JpTMe+Y5KxOchvA==}
+  nodemon@3.1.2:
+    resolution: {integrity: sha512-/Ib/kloefDy+N0iRTxIUzyGcdW9lzlnca2Jsa5w73bs3npXjg+WInmiX6VY13mIb6SykkthYX/U5t0ukryGqBw==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -1433,6 +1436,10 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
@@ -2544,7 +2551,7 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  nodemon@3.1.0:
+  nodemon@3.1.2:
     dependencies:
       chokidar: 3.6.0
       debug: 4.3.4(supports-color@5.5.0)
@@ -2892,6 +2899,8 @@ snapshots:
       punycode: 2.3.1
 
   utils-merge@1.0.1: {}
+
+  uuid@9.0.1: {}
 
   v8-compile-cache-lib@3.0.1: {}
 

--- a/back/src/schedule/index.ts
+++ b/back/src/schedule/index.ts
@@ -1,0 +1,25 @@
+import cors from 'cors'
+import express from 'express'
+
+import { environments } from '../shared/env/environments'
+import { scheduleRouter } from './routes/schedule.routes'
+
+const server = async () => {
+  const PORT = environments.eventPort
+
+  const app = express()
+  app.use(express.json())
+  app.use(cors())
+
+  app.use('/schedule', scheduleRouter)
+
+  app.get('/', (req, res) => {
+    res.send('API Schedule is running! 🦍 🚀')
+  })
+
+  app.listen(PORT, () => {
+    console.log(`Schedule is running on port ${PORT}`)
+  })
+}
+
+server()

--- a/back/src/schedule/modules/delete_schedules_by_event/delete_schedules_controller.ts
+++ b/back/src/schedule/modules/delete_schedules_by_event/delete_schedules_controller.ts
@@ -1,0 +1,44 @@
+import { ScheduleJsonProps } from '../../../shared/domain/entities/schedule'
+import { HttpRequest } from '../../../shared/domain/helpers/http/http_request'
+import {
+  Error,
+  HttpResponse
+} from '../../../shared/domain/helpers/http/http_response'
+import { DeleteScheduleUsecase } from './delete_schedules_usecase'
+import { DeleteScheduleRequest } from './protocols'
+
+interface DeleteScheduleControlerProps {
+  usecase: DeleteScheduleUsecase
+  call(
+    req: HttpRequest<DeleteScheduleRequest>
+  ): Promise<HttpResponse<ScheduleJsonProps> | HttpResponse<Error>>
+}
+
+export class DeleteScheduleController implements DeleteScheduleControlerProps {
+  constructor(public usecase: DeleteScheduleUsecase) {
+    this.usecase = usecase
+  }
+
+  async call(req: HttpRequest<DeleteScheduleRequest>) {
+    const scheduleId = req.data?.id
+
+    if (!scheduleId) {
+      return HttpResponse.badRequest('scheduleId is required')
+    }
+
+    try {
+      const schedule = await this.usecase.call(scheduleId)
+
+      return HttpResponse.ok<ScheduleJsonProps>(
+        'schedule deleted',
+        schedule.toJson()
+      )
+    } catch (error: any) {
+      if (error.message.toLowerCase().includes('not found')) {
+        return HttpResponse.notFound(error.message)
+      }
+
+      return HttpResponse.internalServerError(error.message)
+    }
+  }
+}

--- a/back/src/schedule/modules/delete_schedules_by_event/delete_schedules_presenter.ts
+++ b/back/src/schedule/modules/delete_schedules_by_event/delete_schedules_presenter.ts
@@ -1,0 +1,43 @@
+import { ScheduleJsonProps } from '../../../shared/domain/entities/schedule'
+import { HttpRequest } from '../../../shared/domain/helpers/http/http_request'
+import {
+  Error,
+  HttpResponse
+} from '../../../shared/domain/helpers/http/http_response'
+import { environments } from '../../../shared/env/environments'
+import { ScheduleRepositoryHttp } from '../../shared/infra/repos/schedule_repository_http'
+import { ScheduleRepositoryInterface } from '../../shared/infra/repos/schedule_repository_interface'
+import { ScheduleRepositoryMock } from '../../shared/infra/repos/schedule_repository_mock'
+import { DeleteScheduleController } from './delete_schedules_controller'
+import { DeleteScheduleUsecase } from './delete_schedules_usecase'
+import { DeleteScheduleRequest } from './protocols'
+
+export interface DeleteSchedulePresenterProps {
+  repo: ScheduleRepositoryInterface
+  usecase: DeleteScheduleUsecase
+  controller: DeleteScheduleController
+  call(
+    req: HttpRequest<DeleteScheduleRequest>
+  ): Promise<HttpResponse<ScheduleJsonProps> | HttpResponse<Error>>
+}
+
+const stage = environments.stage
+
+export class DeleteSchedulePresenter implements DeleteSchedulePresenterProps {
+  repo: ScheduleRepositoryInterface
+  usecase: DeleteScheduleUsecase
+  controller: DeleteScheduleController
+
+  constructor() {
+    this.repo =
+      stage === 'test'
+        ? new ScheduleRepositoryMock()
+        : new ScheduleRepositoryHttp()
+    this.usecase = new DeleteScheduleUsecase(this.repo)
+    this.controller = new DeleteScheduleController(this.usecase)
+  }
+
+  async call(req: HttpRequest<DeleteScheduleRequest>) {
+    return await this.controller.call(req)
+  }
+}

--- a/back/src/schedule/modules/delete_schedules_by_event/delete_schedules_usecase.ts
+++ b/back/src/schedule/modules/delete_schedules_by_event/delete_schedules_usecase.ts
@@ -1,0 +1,17 @@
+import { Schedule } from '../../../shared/domain/entities/schedule'
+import { ScheduleRepositoryInterface } from '../../shared/infra/repos/schedule_repository_interface'
+
+export interface DeleteScheduleUsecaseProps {
+  repo: ScheduleRepositoryInterface
+  call(id: string): Promise<Schedule>
+}
+
+export class DeleteScheduleUsecase implements DeleteScheduleUsecaseProps {
+  constructor(public repo: ScheduleRepositoryInterface) {
+    this.repo = repo
+  }
+
+  async call(id: string) {
+    return await this.repo.deleteSchedule(id)
+  }
+}

--- a/back/src/schedule/modules/delete_schedules_by_event/protocols.ts
+++ b/back/src/schedule/modules/delete_schedules_by_event/protocols.ts
@@ -1,0 +1,11 @@
+import { ScheduleJsonProps } from '../../../shared/domain/entities/schedule'
+
+export type DeleteScheduleRequest = {
+  id: string
+}
+
+export type DeleteScheduleResponse = {
+  status: number
+  message: string
+  schedule?: ScheduleJsonProps
+}

--- a/back/src/schedule/modules/get_schedules_by_event/get_schedules_by_event_controller.ts
+++ b/back/src/schedule/modules/get_schedules_by_event/get_schedules_by_event_controller.ts
@@ -1,0 +1,45 @@
+import {
+  Error,
+  HttpResponse
+} from '../../../shared/domain/helpers/http/http_response'
+
+import { HttpRequest } from './../../../shared/domain/helpers/http/http_request'
+import { ScheduleJsonProps } from '../../../shared/domain/entities/schedule'
+import { GetSchedulesByEventUsecase } from './get_schedules_by_event_usecase'
+import { GetSchedulesByEventRequest } from './protocols'
+
+interface GetSchedulesByEventControlerProps {
+  usecase: GetSchedulesByEventUsecase
+  call(
+    req: HttpRequest<GetSchedulesByEventRequest>
+  ): Promise<HttpResponse<ScheduleJsonProps> | HttpResponse<Error>>
+}
+
+export class GetEventController implements GetSchedulesByEventControlerProps {
+  constructor(public usecase: GetSchedulesByEventUsecase) {
+    this.usecase = usecase
+  }
+
+  async call(req: HttpRequest<GetSchedulesByEventRequest>) {
+    const eventId = req.data?.eventId
+
+    if (!eventId) {
+      return HttpResponse.badRequest('eventId is required')
+    }
+
+    try {
+      const schedules = await this.usecase.call(eventId)
+
+      return HttpResponse.ok<ScheduleJsonProps[]>(
+        'schedules found',
+        schedules.map((schedule) => schedule.toJson())
+      )
+    } catch (error: any) {
+      if (error.message.includes('not found')) {
+        return HttpResponse.notFound(error.message)
+      }
+
+      return HttpResponse.internalServerError(error.message)
+    }
+  }
+}

--- a/back/src/schedule/modules/get_schedules_by_event/get_schedules_by_event_controller.ts
+++ b/back/src/schedule/modules/get_schedules_by_event/get_schedules_by_event_controller.ts
@@ -15,7 +15,9 @@ interface GetSchedulesByEventControlerProps {
   ): Promise<HttpResponse<ScheduleJsonProps[]> | HttpResponse<Error>>
 }
 
-export class GetEventController implements GetSchedulesByEventControlerProps {
+export class GetSchedulesByEventController
+  implements GetSchedulesByEventControlerProps
+{
   constructor(public usecase: GetSchedulesByEventUsecase) {
     this.usecase = usecase
   }

--- a/back/src/schedule/modules/get_schedules_by_event/get_schedules_by_event_controller.ts
+++ b/back/src/schedule/modules/get_schedules_by_event/get_schedules_by_event_controller.ts
@@ -12,7 +12,7 @@ interface GetSchedulesByEventControlerProps {
   usecase: GetSchedulesByEventUsecase
   call(
     req: HttpRequest<GetSchedulesByEventRequest>
-  ): Promise<HttpResponse<ScheduleJsonProps> | HttpResponse<Error>>
+  ): Promise<HttpResponse<ScheduleJsonProps[]> | HttpResponse<Error>>
 }
 
 export class GetEventController implements GetSchedulesByEventControlerProps {

--- a/back/src/schedule/modules/get_schedules_by_event/get_schedules_by_event_presenter.ts
+++ b/back/src/schedule/modules/get_schedules_by_event/get_schedules_by_event_presenter.ts
@@ -1,0 +1,44 @@
+import {
+  Error,
+  HttpResponse
+} from '../../../shared/domain/helpers/http/http_response'
+
+import { HttpRequest } from '../../../shared/domain/helpers/http/http_request'
+import { ScheduleJsonProps } from '../../../shared/domain/entities/schedule'
+import { GetSchedulesByEventRequest } from './protocols'
+import { GetSchedulesByEventUsecase } from './get_schedules_by_event_usecase'
+import { GetSchedulesByEventController } from './get_schedules_by_event_controller'
+import { ScheduleRepositoryInterface } from '../../shared/infra/repos/schedule_repository_interface'
+import { environments } from '../../../shared/env/environments'
+import { ScheduleRepositoryMock } from '../../shared/infra/repos/schedule_repository_mock'
+import { ScheduleRepositoryHttp } from '../../shared/infra/repos/schedule_repository_http'
+
+export interface GetEventPresenterProps {
+  repo: ScheduleRepositoryInterface
+  usecase: GetSchedulesByEventUsecase
+  controller: GetSchedulesByEventController
+  call(
+    req: HttpRequest<GetSchedulesByEventRequest>
+  ): Promise<HttpResponse<ScheduleJsonProps[]> | HttpResponse<Error>>
+}
+
+const stage = environments.stage
+
+export class GetSchedulesByEventPresenter implements GetEventPresenterProps {
+  repo: ScheduleRepositoryInterface
+  usecase: GetSchedulesByEventUsecase
+  controller: GetSchedulesByEventController
+
+  constructor() {
+    this.repo =
+      stage === 'test'
+        ? new ScheduleRepositoryMock()
+        : new ScheduleRepositoryHttp()
+    this.usecase = new GetSchedulesByEventUsecase(this.repo)
+    this.controller = new GetSchedulesByEventController(this.usecase)
+  }
+
+  async call(req: HttpRequest<GetSchedulesByEventRequest>) {
+    return await this.controller.call(req)
+  }
+}

--- a/back/src/schedule/modules/get_schedules_by_event/get_schedules_by_event_usecase.ts
+++ b/back/src/schedule/modules/get_schedules_by_event/get_schedules_by_event_usecase.ts
@@ -1,0 +1,19 @@
+import { Schedule } from '../../../shared/domain/entities/schedule'
+import { ScheduleRepositoryInterface } from '../../shared/infra/repos/schedule_repository_interface'
+
+export interface GetSchedulesByEventUsecaseProps {
+  repo: ScheduleRepositoryInterface
+  call(id: string): Promise<Schedule[]>
+}
+
+export class GetSchedulesByEventUsecase
+  implements GetSchedulesByEventUsecaseProps
+{
+  constructor(public repo: ScheduleRepositoryInterface) {
+    this.repo = repo
+  }
+
+  async call(id: string) {
+    return await this.repo.getSchedulesByEventId(id)
+  }
+}

--- a/back/src/schedule/modules/get_schedules_by_event/protocols.ts
+++ b/back/src/schedule/modules/get_schedules_by_event/protocols.ts
@@ -1,0 +1,11 @@
+import { ScheduleJsonProps } from '../../../shared/domain/entities/schedule'
+
+export type GetEventRequest = {
+  id: string
+}
+
+export type GetEventResponse = {
+  status: number
+  message: string
+  event?: ScheduleJsonProps
+}

--- a/back/src/schedule/modules/get_schedules_by_event/protocols.ts
+++ b/back/src/schedule/modules/get_schedules_by_event/protocols.ts
@@ -1,11 +1,11 @@
 import { ScheduleJsonProps } from '../../../shared/domain/entities/schedule'
 
-export type GetEventRequest = {
-  id: string
+export type GetSchedulesByEventRequest = {
+  eventId: string
 }
 
-export type GetEventResponse = {
+export type GetSchedulesByEventResponse = {
   status: number
   message: string
-  event?: ScheduleJsonProps
+  schedules?: ScheduleJsonProps
 }

--- a/back/src/schedule/modules/post_schedule/post_schedule_controller.ts
+++ b/back/src/schedule/modules/post_schedule/post_schedule_controller.ts
@@ -1,0 +1,52 @@
+import { ScheduleJsonProps } from '../../../shared/domain/entities/schedule'
+import { HttpRequest } from '../../../shared/domain/helpers/http/http_request'
+import {
+  Error,
+  HttpResponse
+} from '../../../shared/domain/helpers/http/http_response'
+import { PostScheduleUsecase } from './post_schedule_usecase'
+import { PostScheduleRequest } from './protocols'
+
+interface PostScheduleControllerProps {
+  usecase: PostScheduleUsecase
+  call(
+    req: HttpRequest<PostScheduleRequest>
+  ): Promise<HttpResponse<ScheduleJsonProps> | HttpResponse<Error>>
+}
+
+export class PostScheduleController implements PostScheduleControllerProps {
+  constructor(public usecase: PostScheduleUsecase) {
+    this.usecase = usecase
+  }
+
+  async call(req: HttpRequest<PostScheduleRequest>) {
+    if (!req.data?.eventId && !req.data?.name && !req.data?.time) {
+      return HttpResponse.badRequest('missing body')
+    }
+
+    const { eventId, name, time } = req.data
+
+    if (!eventId) {
+      return HttpResponse.badRequest('missing eventId')
+    }
+
+    if (!name) {
+      return HttpResponse.badRequest('missing name')
+    }
+
+    if (!time) {
+      return HttpResponse.badRequest('missing time')
+    }
+
+    try {
+      const schedule = await this.usecase.call(eventId, time, name)
+
+      return HttpResponse.created<ScheduleJsonProps>(
+        'schedule created',
+        schedule.toJson()
+      )
+    } catch (error: any) {
+      return HttpResponse.internalServerError(error.message)
+    }
+  }
+}

--- a/back/src/schedule/modules/post_schedule/post_schedule_presenter.ts
+++ b/back/src/schedule/modules/post_schedule/post_schedule_presenter.ts
@@ -1,0 +1,44 @@
+import { config } from 'dotenv'
+
+import { ScheduleJsonProps } from '../../../shared/domain/entities/schedule'
+import { HttpRequest } from '../../../shared/domain/helpers/http/http_request'
+import {
+  Error,
+  HttpResponse
+} from '../../../shared/domain/helpers/http/http_response'
+import { ScheduleRepositoryHttp } from '../../shared/infra/repos/schedule_repository_http'
+import { ScheduleRepositoryInterface } from '../../shared/infra/repos/schedule_repository_interface'
+import { ScheduleRepositoryMock } from '../../shared/infra/repos/schedule_repository_mock'
+import { PostScheduleController } from './post_schedule_controller'
+import { PostScheduleUsecase } from './post_schedule_usecase'
+import { PostScheduleRequest } from './protocols'
+
+config()
+
+export interface PostSchedulePresenterProps {
+  repo: ScheduleRepositoryInterface
+  usecase: PostScheduleUsecase
+  controller: PostScheduleController
+  call(
+    req: HttpRequest<PostScheduleRequest>
+  ): Promise<HttpResponse<ScheduleJsonProps> | HttpResponse<Error>>
+}
+
+const stage = process.env.STAGE || 'test'
+
+export class PostSchedulePresenter implements PostSchedulePresenterProps {
+  repo: ScheduleRepositoryInterface
+  usecase: PostScheduleUsecase
+  controller: PostScheduleController
+
+  constructor() {
+    this.repo =
+      stage === 'test' ? new ScheduleRepositoryMock() : new ScheduleRepositoryHttp()
+    this.usecase = new PostScheduleUsecase(this.repo)
+    this.controller = new PostScheduleController(this.usecase)
+  }
+
+  async call(req: HttpRequest<PostScheduleRequest>) {
+    return await this.controller.call(req)
+  }
+}

--- a/back/src/schedule/modules/post_schedule/post_schedule_usecase.ts
+++ b/back/src/schedule/modules/post_schedule/post_schedule_usecase.ts
@@ -1,0 +1,26 @@
+import { Schedule } from '../../../shared/domain/entities/schedule'
+import { ScheduleRepositoryInterface } from '../../shared/infra/repos/schedule_repository_interface'
+import { v4 as uuidv4 } from 'uuid'
+
+export interface PostScheduleUsecaseProps {
+  repo: ScheduleRepositoryInterface
+  call(eventId: string, time: number, name: string): Promise<Schedule>
+}
+
+export class PostScheduleUsecase implements PostScheduleUsecaseProps {
+  constructor(public repo: ScheduleRepositoryInterface) {
+    this.repo = repo
+  }
+  
+  async call(eventId: string, time: number, name: string) {
+
+    // TODO: Verify if event exists
+    
+    return await this.repo.createSchedule({
+      id: uuidv4(),
+      eventId,
+      time,
+      name
+    })
+  }
+}

--- a/back/src/schedule/modules/post_schedule/protocols.ts
+++ b/back/src/schedule/modules/post_schedule/protocols.ts
@@ -1,0 +1,13 @@
+import { ScheduleJsonProps } from '../../../shared/domain/entities/schedule'
+
+export type PostScheduleRequest = {
+  eventId: string
+  time: number
+  name: string
+}
+
+export type PostScheduleResponse = {
+  status: number
+  message: string
+  schedule?: ScheduleJsonProps
+}

--- a/back/src/schedule/routes/schedule.routes.ts
+++ b/back/src/schedule/routes/schedule.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 
 import { HttpRequest } from '../../shared/domain/helpers/http/http_request'
+import { DeleteSchedulePresenter } from '../modules/delete_schedules_by_event/delete_schedules_presenter'
 import { GetSchedulesByEventPresenter } from '../modules/get_schedules_by_event/get_schedules_by_event_presenter'
 
 export const scheduleRouter = Router()
@@ -8,6 +9,15 @@ export const scheduleRouter = Router()
 scheduleRouter.get('/eventId=:eventId', async (req, res) => {
   const request = new HttpRequest('get', req.params)
   const presenter = new GetSchedulesByEventPresenter()
+  const response = await presenter.call(request)
+  res
+    .status(response.status)
+    .json({ message: response.message, data: response.data })
+})
+
+scheduleRouter.delete('/scheduleId=:id', async (req, res) => {
+  const request = new HttpRequest('delete', req.params)
+  const presenter = new DeleteSchedulePresenter()
   const response = await presenter.call(request)
   res
     .status(response.status)

--- a/back/src/schedule/routes/schedule.routes.ts
+++ b/back/src/schedule/routes/schedule.routes.ts
@@ -1,0 +1,5 @@
+import { Router } from 'express'
+
+import { HttpRequest } from '../../shared/domain/helpers/http/http_request'
+
+export const scheduleRouter = Router()

--- a/back/src/schedule/routes/schedule.routes.ts
+++ b/back/src/schedule/routes/schedule.routes.ts
@@ -1,5 +1,15 @@
 import { Router } from 'express'
 
 import { HttpRequest } from '../../shared/domain/helpers/http/http_request'
+import { GetSchedulesByEventPresenter } from '../modules/get_schedules_by_event/get_schedules_by_event_presenter'
 
 export const scheduleRouter = Router()
+
+scheduleRouter.get('/eventId=:eventId', async (req, res) => {
+  const request = new HttpRequest('get', req.params)
+  const presenter = new GetSchedulesByEventPresenter()
+  const response = await presenter.call(request)
+  res
+    .status(response.status)
+    .json({ message: response.message, data: response.data })
+})

--- a/back/src/schedule/routes/schedule.routes.ts
+++ b/back/src/schedule/routes/schedule.routes.ts
@@ -2,12 +2,22 @@ import { Router } from 'express'
 
 import { HttpRequest } from '../../shared/domain/helpers/http/http_request'
 import { GetSchedulesByEventPresenter } from '../modules/get_schedules_by_event/get_schedules_by_event_presenter'
+import { PostSchedulePresenter } from '../modules/post_schedule/post_schedule_presenter'
 
 export const scheduleRouter = Router()
 
 scheduleRouter.get('/eventId=:eventId', async (req, res) => {
   const request = new HttpRequest('get', req.params)
   const presenter = new GetSchedulesByEventPresenter()
+  const response = await presenter.call(request)
+  res
+    .status(response.status)
+    .json({ message: response.message, data: response.data })
+})
+
+scheduleRouter.post('/eventId=:eventId', async (req, res) => {
+  const request = new HttpRequest('post', req.body)
+  const presenter = new PostSchedulePresenter()
   const response = await presenter.call(request)
   res
     .status(response.status)

--- a/back/src/schedule/shared/infra/repos/schedule_repository_http.ts
+++ b/back/src/schedule/shared/infra/repos/schedule_repository_http.ts
@@ -7,7 +7,12 @@ export class ScheduleRepositoryHttp implements ScheduleRepositoryInterface {
   getSchedulesByEventId(eventId: string): Promise<Schedule[]> {
     throw new Error('Method not implemented.')
   }
-  createSchedule(schedule: { eventId: string; time: number; name: string }): Promise<Schedule> {
+  createSchedule(schedule: {
+    id: string
+    eventId: string
+    time: number
+    name: string
+  }): Promise<Schedule> {
     throw new Error('Method not implemented.')
   }
   deleteSchedule(scheduleId: string): Promise<Schedule> {

--- a/back/src/schedule/shared/infra/repos/schedule_repository_http.ts
+++ b/back/src/schedule/shared/infra/repos/schedule_repository_http.ts
@@ -1,13 +1,15 @@
-import { Event } from '../../../../shared/domain/entities/event'
 import { Schedule } from '../../../../shared/domain/entities/schedule'
-import { NotFoundError } from '../../../../shared/domain/helpers/errors/not_found'
 import { ScheduleRepositoryInterface } from './schedule_repository_interface'
 
 export class ScheduleRepositoryHttp implements ScheduleRepositoryInterface {
   getSchedulesByEventId(eventId: string): Promise<Schedule[]> {
     throw new Error('Method not implemented.')
   }
-  createSchedule(schedule: { eventId: string; time: number; name: string }): Promise<Schedule> {
+  createSchedule(schedule: {
+    eventId: string
+    time: number
+    name: string
+  }): Promise<Schedule> {
     throw new Error('Method not implemented.')
   }
   deleteSchedule(scheduleId: string): Promise<Schedule> {

--- a/back/src/schedule/shared/infra/repos/schedule_repository_http.ts
+++ b/back/src/schedule/shared/infra/repos/schedule_repository_http.ts
@@ -1,0 +1,16 @@
+import { Event } from '../../../../shared/domain/entities/event'
+import { Schedule } from '../../../../shared/domain/entities/schedule'
+import { NotFoundError } from '../../../../shared/domain/helpers/errors/not_found'
+import { ScheduleRepositoryInterface } from './schedule_repository_interface'
+
+export class ScheduleRepositoryHttp implements ScheduleRepositoryInterface {
+  getSchedulesByEventId(eventId: string): Promise<Schedule[]> {
+    throw new Error('Method not implemented.')
+  }
+  createSchedule(schedule: { eventId: string; time: number; name: string }): Promise<Schedule> {
+    throw new Error('Method not implemented.')
+  }
+  deleteSchedule(scheduleId: string): Promise<Schedule> {
+    throw new Error('Method not implemented.')
+  }
+}

--- a/back/src/schedule/shared/infra/repos/schedule_repository_interface.ts
+++ b/back/src/schedule/shared/infra/repos/schedule_repository_interface.ts
@@ -1,0 +1,12 @@
+import { Schedule } from '../../../../shared/domain/entities/schedule'
+
+export interface ScheduleRepositoryInterface {
+  getSchedulesByEventId(eventId: string): Promise<Schedule[]>
+  createSchedule(schedule: {
+    eventId: string
+    time: number
+    name: string
+  }): Promise<Schedule>
+  deleteSchedule(scheduleId: string): Promise<Schedule>
+  // Batch operations?
+}

--- a/back/src/schedule/shared/infra/repos/schedule_repository_interface.ts
+++ b/back/src/schedule/shared/infra/repos/schedule_repository_interface.ts
@@ -3,6 +3,7 @@ import { Schedule } from '../../../../shared/domain/entities/schedule'
 export interface ScheduleRepositoryInterface {
   getSchedulesByEventId(eventId: string): Promise<Schedule[]>
   createSchedule(schedule: {
+    id: string
     eventId: string
     time: number
     name: string

--- a/back/src/schedule/shared/infra/repos/schedule_repository_mock.ts
+++ b/back/src/schedule/shared/infra/repos/schedule_repository_mock.ts
@@ -1,0 +1,99 @@
+import { Event } from '../../../../shared/domain/entities/event'
+import { Schedule } from '../../../../shared/domain/entities/schedule'
+import { NotFoundError } from '../../../../shared/domain/helpers/errors/not_found'
+import { ScheduleRepositoryInterface } from './schedule_repository_interface'
+import { v4 as uuidv4 } from 'uuid'
+
+export class ScheduleRepositoryMock implements ScheduleRepositoryInterface {
+  static schedules = [
+    new Schedule(
+      '3bdea174-7ae8-474b-a649-93be4620bba6',
+      '1',
+      1632940200000, // 1632940200000 = 29/09/2021 18:30:00 (GMT-3)
+      'Vini'
+    ),
+    new Schedule(
+      '17d97cbb-d308-47c8-bb83-ddc7116d23fd',
+      '1',
+      1632940200000, // 1632940200000 = 29/09/2021 18:30:00 (GMT-3)
+      'Bossini'
+    ),
+    new Schedule(
+      'c8a559fc-6794-4587-84f5-a3efc2392921',
+      '1',
+      1632940200000, // 1632940200000 = 29/09/2021 18:30:00 (GMT-3)
+      'Soller'
+    ),
+
+    new Schedule(
+      '77f361af-7e88-409b-92c0-cdeae2f19399',
+      '2',
+      1632940200000, // 1632940200000 = 29/09/2021 18:30:00 (GMT-3)
+      'Sakamoto'
+    ),
+    new Schedule(
+      '3fde5c12-cfee-46d8-9469-d77de8370739',
+      '2',
+      1632942000000, // 1632942000000 = 29/09/2021 19:00:00 (GMT-3)
+      'Flavio'
+    ),
+    new Schedule(
+      'ba096c65-bca0-4242-98b1-383e85f6e930',
+      '2',
+      1632942000000, // 1632942000000 = 29/09/2021 19:00:00 (GMT-3)
+      'João'
+    ),
+
+    new Schedule(
+      '26d391f9-96b2-408e-89c6-5afc0ac2ec92',
+      '3',
+      1632939300000, // 1632940200000 = 29/09/2021 18:15:00 (GMT-3)
+      'Matumoto'
+    ),
+    new Schedule(
+      '04becde3-2b94-4a7b-967c-897b9426c432',
+      '3',
+      1632942000000, // 1632940200000 = 29/09/2021 19:00:00 (GMT-3)
+      'Bossini'
+    )
+  ]
+
+  getSchedulesByEventId(eventId: string): Promise<Schedule[]> {
+    const schedules = ScheduleRepositoryMock.schedules.filter(
+      (schedule) => schedule.eventId === eventId
+    )
+    return Promise.resolve(schedules)
+  }
+
+  createSchedule(schedule: {
+    eventId: string
+    time: number
+    name: string
+  }): Promise<Schedule> {
+    const newSchedule = new Schedule(
+      uuidv4(),
+      schedule.eventId,
+      schedule.time,
+      schedule.name
+    )
+
+    ScheduleRepositoryMock.schedules.push(newSchedule)
+
+    return Promise.resolve(newSchedule)
+  }
+
+  deleteSchedule(scheduleId: string): Promise<Schedule> {
+    const scheduleIndex = ScheduleRepositoryMock.schedules.findIndex(
+      (schedule) => schedule.id === scheduleId
+    )
+
+    if (scheduleIndex === -1) {
+      throw new NotFoundError('Schedule not found')
+    }
+
+    const schedule = ScheduleRepositoryMock.schedules[scheduleIndex]
+    ScheduleRepositoryMock.schedules.splice(scheduleIndex, 1)
+
+    return Promise.resolve(schedule)
+  }
+}

--- a/back/src/schedule/shared/infra/repos/schedule_repository_mock.ts
+++ b/back/src/schedule/shared/infra/repos/schedule_repository_mock.ts
@@ -1,8 +1,8 @@
-import { Event } from '../../../../shared/domain/entities/event'
+import { v4 as uuidv4 } from 'uuid'
+
 import { Schedule } from '../../../../shared/domain/entities/schedule'
 import { NotFoundError } from '../../../../shared/domain/helpers/errors/not_found'
 import { ScheduleRepositoryInterface } from './schedule_repository_interface'
-import { v4 as uuidv4 } from 'uuid'
 
 export class ScheduleRepositoryMock implements ScheduleRepositoryInterface {
   static schedules = [
@@ -88,12 +88,67 @@ export class ScheduleRepositoryMock implements ScheduleRepositoryInterface {
     )
 
     if (scheduleIndex === -1) {
-      throw new NotFoundError('Schedule not found')
+      throw new NotFoundError('schedule')
     }
 
     const schedule = ScheduleRepositoryMock.schedules[scheduleIndex]
     ScheduleRepositoryMock.schedules.splice(scheduleIndex, 1)
 
     return Promise.resolve(schedule)
+  }
+
+  resetMock() {
+    ScheduleRepositoryMock.schedules = [
+      new Schedule(
+        '3bdea174-7ae8-474b-a649-93be4620bba6',
+        '1',
+        1632940200000, // 1632940200000 = 29/09/2021 18:30:00 (GMT-3)
+        'Vini'
+      ),
+      new Schedule(
+        '17d97cbb-d308-47c8-bb83-ddc7116d23fd',
+        '1',
+        1632940200000, // 1632940200000 = 29/09/2021 18:30:00 (GMT-3)
+        'Bossini'
+      ),
+      new Schedule(
+        'c8a559fc-6794-4587-84f5-a3efc2392921',
+        '1',
+        1632940200000, // 1632940200000 = 29/09/2021 18:30:00 (GMT-3)
+        'Soller'
+      ),
+
+      new Schedule(
+        '77f361af-7e88-409b-92c0-cdeae2f19399',
+        '2',
+        1632940200000, // 1632940200000 = 29/09/2021 18:30:00 (GMT-3)
+        'Sakamoto'
+      ),
+      new Schedule(
+        '3fde5c12-cfee-46d8-9469-d77de8370739',
+        '2',
+        1632942000000, // 1632942000000 = 29/09/2021 19:00:00 (GMT-3)
+        'Flavio'
+      ),
+      new Schedule(
+        'ba096c65-bca0-4242-98b1-383e85f6e930',
+        '2',
+        1632942000000, // 1632942000000 = 29/09/2021 19:00:00 (GMT-3)
+        'João'
+      ),
+
+      new Schedule(
+        '26d391f9-96b2-408e-89c6-5afc0ac2ec92',
+        '3',
+        1632939300000, // 1632940200000 = 29/09/2021 18:15:00 (GMT-3)
+        'Matumoto'
+      ),
+      new Schedule(
+        '04becde3-2b94-4a7b-967c-897b9426c432',
+        '3',
+        1632942000000, // 1632940200000 = 29/09/2021 19:00:00 (GMT-3)
+        'Bossini'
+      )
+    ]
   }
 }

--- a/back/src/schedule/shared/infra/repos/schedule_repository_mock.ts
+++ b/back/src/schedule/shared/infra/repos/schedule_repository_mock.ts
@@ -2,7 +2,6 @@ import { Event } from '../../../../shared/domain/entities/event'
 import { Schedule } from '../../../../shared/domain/entities/schedule'
 import { NotFoundError } from '../../../../shared/domain/helpers/errors/not_found'
 import { ScheduleRepositoryInterface } from './schedule_repository_interface'
-import { v4 as uuidv4 } from 'uuid'
 
 export class ScheduleRepositoryMock implements ScheduleRepositoryInterface {
   static schedules = [
@@ -66,12 +65,13 @@ export class ScheduleRepositoryMock implements ScheduleRepositoryInterface {
   }
 
   createSchedule(schedule: {
+    id: string
     eventId: string
     time: number
     name: string
   }): Promise<Schedule> {
     const newSchedule = new Schedule(
-      uuidv4(),
+      schedule.id,
       schedule.eventId,
       schedule.time,
       schedule.name

--- a/back/src/shared/domain/entities/schedule.ts
+++ b/back/src/shared/domain/entities/schedule.ts
@@ -1,78 +1,73 @@
-export interface ScheduleInterface {
-    
-}
+export interface ScheduleInterface {}
 
 export type ScheduleJsonProps = {
-
+  id: string
+  event_id: string
+  time: number
+  name: string
 }
 
 export class Schedule implements ScheduleInterface {
-    private _id: string
-    private _eventId: string
-    private _time: number
-    private _name: string
+  private _id: string
+  private _eventId: string
+  private _time: number
+  private _name: string
 
-    constructor(
-        id: string,
-        eventId: string,
-        time: number,
-        name: string
-    ) {
-        this._id = id
-        this._eventId = eventId
-        this._time = time
-        this._name = name
-    }
+  constructor(id: string, eventId: string, time: number, name: string) {
+    this._id = id
+    this._eventId = eventId
+    this._time = time
+    this._name = name
+  }
 
-    equal(schedule: Schedule) {
-        return (
-            this._id === schedule._id &&
-            this._eventId === schedule._eventId &&
-            this._time === schedule._time &&
-            this._name === schedule._name
-        )
-    }
+  equal(schedule: Schedule) {
+    return (
+      this._id === schedule._id &&
+      this._eventId === schedule._eventId &&
+      this._time === schedule._time &&
+      this._name === schedule._name
+    )
+  }
 
-    toJson() {
-        return {
-            id: this._id,
-            event_id: this._eventId,
-            time: this._time,
-            name: this._name
-        }
+  toJson() {
+    return {
+      id: this._id,
+      event_id: this._eventId,
+      time: this._time,
+      name: this._name
     }
+  }
 
-    // Getters and Setters
-    get id() {
-        return this._id
-    }
+  // Getters and Setters
+  get id() {
+    return this._id
+  }
 
-    get eventId() {
-        return this._eventId
-    }
+  get eventId() {
+    return this._eventId
+  }
 
-    get time() {
-        return this._time
-    }
+  get time() {
+    return this._time
+  }
 
-    get name() {
-        return this._name
-    }
+  get name() {
+    return this._name
+  }
 
-    set id(id: string) {
-        this._id = id
-    }
+  set id(id: string) {
+    this._id = id
+  }
 
-    set eventId(eventId: string) {
-        this._eventId = eventId
-    }
+  set eventId(eventId: string) {
+    this._eventId = eventId
+  }
 
-    set time(time: number) {
-        this._time = time
-    }
+  set time(time: number) {
+    this._time = time
+  }
 
-    set name(name: string) {
-        this._name = name
-    }
-    
+  set name(name: string) {
+    this._name = name
+  }
 }

--- a/back/src/shared/domain/entities/schedule.ts
+++ b/back/src/shared/domain/entities/schedule.ts
@@ -1,0 +1,93 @@
+// export interface EventInterface {
+//     calculateTotalTime(): number
+//     calculateCellNumbers(): number
+//     equals(event: Event): boolean
+//     toJson(): EventJsonProps
+//   }
+  
+//   export type EventJsonProps = {
+//     id: string
+//     name: string
+//     start_date: number
+//     end_date: number
+//     time_interval: number
+//   }
+  
+export interface ScheduleInterface {
+    
+}
+
+export type ScheduleJsonProps = {
+
+}
+
+export class Schedule implements ScheduleInterface {
+    private _id: string
+    private _eventId: string
+    private _time: number
+    private _name: string
+
+    constructor(
+        id: string,
+        eventId: string,
+        time: number,
+        name: string
+    ) {
+        this._id = id
+        this._eventId = eventId
+        this._time = time
+        this._name = name
+    }
+
+    equal(schedule: Schedule) {
+        return (
+            this._id === schedule._id &&
+            this._eventId === schedule._eventId &&
+            this._time === schedule._time &&
+            this._name === schedule._name
+        )
+    }
+
+    toJson() {
+        return {
+            id: this._id,
+            event_id: this._eventId,
+            time: this._time,
+            name: this._name
+        }
+    }
+
+    // Getters and Setters
+    get id() {
+        return this._id
+    }
+
+    get eventId() {
+        return this._eventId
+    }
+
+    get time() {
+        return this._time
+    }
+
+    get name() {
+        return this._name
+    }
+
+    set id(id: string) {
+        this._id = id
+    }
+
+    set eventId(eventId: string) {
+        this._eventId = eventId
+    }
+
+    set time(time: number) {
+        this._time = time
+    }
+
+    set name(name: string) {
+        this._name = name
+    }
+    
+}

--- a/back/src/shared/domain/entities/schedule.ts
+++ b/back/src/shared/domain/entities/schedule.ts
@@ -1,18 +1,3 @@
-// export interface EventInterface {
-//     calculateTotalTime(): number
-//     calculateCellNumbers(): number
-//     equals(event: Event): boolean
-//     toJson(): EventJsonProps
-//   }
-  
-//   export type EventJsonProps = {
-//     id: string
-//     name: string
-//     start_date: number
-//     end_date: number
-//     time_interval: number
-//   }
-  
 export interface ScheduleInterface {
     
 }

--- a/back/tests/schedule/modules/delete_schedules/delete_schedule_controller.test.ts
+++ b/back/tests/schedule/modules/delete_schedules/delete_schedule_controller.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from 'vitest'
+
+import { DeleteScheduleController } from '../../../../src/schedule/modules/delete_schedules_by_event/delete_schedules_controller'
+import { DeleteScheduleUsecase } from '../../../../src/schedule/modules/delete_schedules_by_event/delete_schedules_usecase'
+import { ScheduleRepositoryMock } from '../../../../src/schedule/shared/infra/repos/schedule_repository_mock'
+import { HttpRequest } from '../../../../src/shared/domain/helpers/http/http_request'
+import { HTTP_STATUS_CODE } from '../../../../src/shared/domain/helpers/http/http_status_code'
+
+test('Test delete schedule controller without id', async () => {
+  const repo = new ScheduleRepositoryMock()
+  const usecase = new DeleteScheduleUsecase(repo)
+  const controller = new DeleteScheduleController(usecase)
+  const request = new HttpRequest('delete', {
+    id: ''
+  })
+  const response = await controller.call(request)
+  expect(response.status).toBe(HTTP_STATUS_CODE.BAD_REQUEST)
+  expect(response.message).toBe('scheduleId is required')
+  expect(response.data).toBe(undefined)
+})
+
+test('Test delete event controller not found', async () => {
+  const repo = new ScheduleRepositoryMock()
+  const usecase = new DeleteScheduleUsecase(repo)
+  const controller = new DeleteScheduleController(usecase)
+  const request = new HttpRequest('delete', {
+    id: 'bdea174-7ae8-474b-93be4620bba6'
+  })
+  const response = await controller.call(request)
+  expect(response.status).toBe(HTTP_STATUS_CODE.NOT_FOUND)
+  expect(response.message).toBe('schedule not found')
+  expect(response.data).toBe(undefined)
+})
+
+test('Test delete schedule controller found', async () => {
+  const repo = new ScheduleRepositoryMock()
+  const usecase = new DeleteScheduleUsecase(repo)
+  const controller = new DeleteScheduleController(usecase)
+  const request = new HttpRequest('delete', {
+    id: '3fde5c12-cfee-46d8-9469-d77de8370739'
+  })
+  const response = await controller.call(request)
+  const scheduleExpect = {
+    time: 1632942000000,
+    id: '3fde5c12-cfee-46d8-9469-d77de8370739',
+    event_id: '2',
+    name: 'Flavio'
+  }
+  expect(response.status).toBe(HTTP_STATUS_CODE.OK)
+  expect(response.message).toBe('schedule deleted')
+  expect(response.data).toEqual(scheduleExpect)
+  repo.resetMock()
+})

--- a/back/tests/schedule/modules/delete_schedules/delete_schedule_presenter.test.ts
+++ b/back/tests/schedule/modules/delete_schedules/delete_schedule_presenter.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from 'vitest'
+
+import { DeleteSchedulePresenter } from '../../../../src/schedule/modules/delete_schedules_by_event/delete_schedules_presenter'
+import { ScheduleRepositoryMock } from '../../../../src/schedule/shared/infra/repos/schedule_repository_mock'
+import { HttpRequest } from '../../../../src/shared/domain/helpers/http/http_request'
+import { HTTP_STATUS_CODE } from '../../../../src/shared/domain/helpers/http/http_status_code'
+
+test('Test delete schedule presenter found', async () => {
+  const repo = new ScheduleRepositoryMock()
+  const presenter = new DeleteSchedulePresenter()
+  const request = new HttpRequest('delete', {
+    id: '3fde5c12-cfee-46d8-9469-d77de8370739'
+  })
+  const response = await presenter.call(request)
+  const scheduleExpect = {
+    id: '3fde5c12-cfee-46d8-9469-d77de8370739',
+    event_id: '2',
+    time: 1632942000000,
+    name: 'Flavio'
+  }
+  expect(response.status).toBe(HTTP_STATUS_CODE.OK)
+  expect(response.message).toBe('schedule deleted')
+  expect(response.data).toEqual(scheduleExpect)
+  repo.resetMock()
+})
+
+test('Test delete event presenter not found', async () => {
+  const presenter = new DeleteSchedulePresenter()
+  const request = new HttpRequest('delete', { id: '4' })
+  const response = await presenter.call(request)
+  expect(response.status).toBe(HTTP_STATUS_CODE.NOT_FOUND)
+  expect(response.message).toBe('schedule not found')
+  expect(response.data).toBe(undefined)
+})

--- a/back/tests/schedule/modules/delete_schedules/delete_schedule_usecase.test.ts
+++ b/back/tests/schedule/modules/delete_schedules/delete_schedule_usecase.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'vitest'
+
+import { DeleteScheduleUsecase } from '../../../../src/schedule/modules/delete_schedules_by_event/delete_schedules_usecase'
+import { ScheduleRepositoryMock } from '../../../../src/schedule/shared/infra/repos/schedule_repository_mock'
+import { Schedule } from '../../../../src/shared/domain/entities/schedule'
+
+test('Test delete schedule usecase found', async () => {
+  const repo = new ScheduleRepositoryMock()
+  const usecase = new DeleteScheduleUsecase(repo)
+  const schedule = await usecase.call('3fde5c12-cfee-46d8-9469-d77de8370739')
+
+  expect(schedule).toBeInstanceOf(Schedule)
+  expect(schedule?.id).toBe('3fde5c12-cfee-46d8-9469-d77de8370739')
+  expect(schedule?.eventId).toBe('2')
+  expect(schedule?.time).toBe(1632942000000)
+  expect(schedule?.name).toBe('Flavio')
+  repo.resetMock()
+})
+
+test('Test delete schedule usecase not found', () => {
+  const repo = new ScheduleRepositoryMock()
+  const usecase = new DeleteScheduleUsecase(repo)
+  expect(async () => {
+    await usecase.call('1001')
+  }).rejects.toThrowError('schedule not found')
+})

--- a/back/tests/schedule/modules/get_schedules_by_event/get_schedules_by_event_controller.test.ts
+++ b/back/tests/schedule/modules/get_schedules_by_event/get_schedules_by_event_controller.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from 'vitest'
+
+import { EventRepositoryMock } from '../../../../src/event/shared/infra/repos/event_repository_mock'
+import { HTTP_STATUS_CODE } from '../../../../src/shared/domain/helpers/http/http_status_code'
+import { HttpRequest } from '../../../../src/shared/domain/helpers/http/http_request'
+import { ScheduleRepositoryMock } from '../../../../src/schedule/shared/infra/repos/schedule_repository_mock'
+import { GetSchedulesByEventUsecase } from '../../../../src/schedule/modules/get_schedules_by_event/get_schedules_by_event_usecase'
+import { GetEventController } from '../../../../src/schedule/modules/get_schedules_by_event/get_schedules_by_event_controller'
+
+test('Test get schedule by event controller without eventId', async () => {
+  const repo = new ScheduleRepositoryMock()
+  const usecase = new GetSchedulesByEventUsecase(repo)
+  const controller = new GetEventController(usecase)
+  const request = new HttpRequest('get', { eventId: '' })
+  const response = await controller.call(request)
+  expect(response.status).toBe(HTTP_STATUS_CODE.BAD_REQUEST)
+  expect(response.message).toBe('eventId is required')
+  expect(response.data).toBe(undefined)
+})
+
+// test('Test get event controller without id', async () => {
+//   const repo = new EventRepositoryMock()
+//   const usecase = new GetEventUsecase(repo)
+//   const controller = new GetEventController(usecase)
+//   const request = new HttpRequest('get', { id: '' })
+//   const response = await controller.call(request)
+//   expect(response.status).toBe(HTTP_STATUS_CODE.BAD_REQUEST)
+//   expect(response.message).toBe('id is required')
+//   expect(response.data).toBe(undefined)
+// })

--- a/back/tests/schedule/modules/get_schedules_by_event/get_schedules_by_event_controller.test.ts
+++ b/back/tests/schedule/modules/get_schedules_by_event/get_schedules_by_event_controller.test.ts
@@ -18,19 +18,12 @@ test('Test get schedule by event controller without eventId', async () => {
   expect(response.data).toBe(undefined)
 })
 
-test('Test get schedule by event controller returns an array', async () => {
+test('Test get schedule by event controller returns an object', async () => {
   const repo = new ScheduleRepositoryMock()
   const usecase = new GetSchedulesByEventUsecase(repo)
   const controller = new GetSchedulesByEventController(usecase)
   const request = new HttpRequest('get', { eventId: '2' })
   const response = await controller.call(request)
-  const scheduleExpect = {
-    id: '2',
-    event_id: '2',
-    start_date: 1632950200000,
-    end_date: 1632954000000,
-    time_interval: 300000
-  }
   expect(response.status).toBe(HTTP_STATUS_CODE.OK)
   expect(response.message).toBe('schedules found')
   expect(response.data).toBeTypeOf('object')

--- a/back/tests/schedule/modules/get_schedules_by_event/get_schedules_by_event_controller.test.ts
+++ b/back/tests/schedule/modules/get_schedules_by_event/get_schedules_by_event_controller.test.ts
@@ -5,12 +5,12 @@ import { HTTP_STATUS_CODE } from '../../../../src/shared/domain/helpers/http/htt
 import { HttpRequest } from '../../../../src/shared/domain/helpers/http/http_request'
 import { ScheduleRepositoryMock } from '../../../../src/schedule/shared/infra/repos/schedule_repository_mock'
 import { GetSchedulesByEventUsecase } from '../../../../src/schedule/modules/get_schedules_by_event/get_schedules_by_event_usecase'
-import { GetEventController } from '../../../../src/schedule/modules/get_schedules_by_event/get_schedules_by_event_controller'
+import { GetSchedulesByEventController } from '../../../../src/schedule/modules/get_schedules_by_event/get_schedules_by_event_controller'
 
 test('Test get schedule by event controller without eventId', async () => {
   const repo = new ScheduleRepositoryMock()
   const usecase = new GetSchedulesByEventUsecase(repo)
-  const controller = new GetEventController(usecase)
+  const controller = new GetSchedulesByEventController(usecase)
   const request = new HttpRequest('get', { eventId: '' })
   const response = await controller.call(request)
   expect(response.status).toBe(HTTP_STATUS_CODE.BAD_REQUEST)
@@ -18,13 +18,20 @@ test('Test get schedule by event controller without eventId', async () => {
   expect(response.data).toBe(undefined)
 })
 
-// test('Test get event controller without id', async () => {
-//   const repo = new EventRepositoryMock()
-//   const usecase = new GetEventUsecase(repo)
-//   const controller = new GetEventController(usecase)
-//   const request = new HttpRequest('get', { id: '' })
-//   const response = await controller.call(request)
-//   expect(response.status).toBe(HTTP_STATUS_CODE.BAD_REQUEST)
-//   expect(response.message).toBe('id is required')
-//   expect(response.data).toBe(undefined)
-// })
+test('Test get schedule by event controller returns an array', async () => {
+  const repo = new ScheduleRepositoryMock()
+  const usecase = new GetSchedulesByEventUsecase(repo)
+  const controller = new GetSchedulesByEventController(usecase)
+  const request = new HttpRequest('get', { eventId: '2' })
+  const response = await controller.call(request)
+  const scheduleExpect = {
+    id: '2',
+    event_id: '2',
+    start_date: 1632950200000,
+    end_date: 1632954000000,
+    time_interval: 300000
+  }
+  expect(response.status).toBe(HTTP_STATUS_CODE.OK)
+  expect(response.message).toBe('schedules found')
+  expect(response.data).toBeTypeOf('object')
+})

--- a/back/tests/schedule/modules/get_schedules_by_event/get_schedules_by_event_presenter.test.ts
+++ b/back/tests/schedule/modules/get_schedules_by_event/get_schedules_by_event_presenter.test.ts
@@ -1,20 +1,15 @@
 import { test, expect } from 'vitest'
 import { GetSchedulesByEventPresenter } from '../../../../src/schedule/modules/get_schedules_by_event/get_schedules_by_event_presenter'
 import { HttpRequest } from '../../../../src/shared/domain/helpers/http/http_request'
+import { HTTP_STATUS_CODE } from '../../../../src/shared/domain/helpers/http/http_status_code'
 
-test('Test get event presenter found', async () => {
+test('Test get schedule by event presenter returns an object', async () => {
   const presenter = new GetSchedulesByEventPresenter()
   const response = await presenter.call(
     new HttpRequest('get', { eventId: '2' })
   )
-  const eventExpect = {
-    id: '2',
-    name: 'Academy Chest Day',
-    start_date: 1632950200000,
-    end_date: 1632954000000,
-    time_interval: 300000
-  }
-  expect(response.status).toBe(200)
-  expect(response.message).toBe('schedule found')
-  expect(response.data).toEqual(eventExpect)
+
+  expect(response.status).toBe(HTTP_STATUS_CODE.OK)
+  expect(response.message).toBe('schedules found')
+  expect(response.data).toBeTypeOf('object')
 })

--- a/back/tests/schedule/modules/get_schedules_by_event/get_schedules_by_event_presenter.test.ts
+++ b/back/tests/schedule/modules/get_schedules_by_event/get_schedules_by_event_presenter.test.ts
@@ -1,0 +1,20 @@
+import { test, expect } from 'vitest'
+import { GetSchedulesByEventPresenter } from '../../../../src/schedule/modules/get_schedules_by_event/get_schedules_by_event_presenter'
+import { HttpRequest } from '../../../../src/shared/domain/helpers/http/http_request'
+
+test('Test get event presenter found', async () => {
+  const presenter = new GetSchedulesByEventPresenter()
+  const response = await presenter.call(
+    new HttpRequest('get', { eventId: '2' })
+  )
+  const eventExpect = {
+    id: '2',
+    name: 'Academy Chest Day',
+    start_date: 1632950200000,
+    end_date: 1632954000000,
+    time_interval: 300000
+  }
+  expect(response.status).toBe(200)
+  expect(response.message).toBe('schedule found')
+  expect(response.data).toEqual(eventExpect)
+})

--- a/back/tests/schedule/modules/get_schedules_by_event/get_schedules_by_event_usecase.test.ts
+++ b/back/tests/schedule/modules/get_schedules_by_event/get_schedules_by_event_usecase.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'vitest'
+
+import { GetSchedulesByEventUsecase } from '../../../../src/schedule/modules/get_schedules_by_event/get_schedules_by_event_usecase'
+import { ScheduleRepositoryMock } from '../../../../src/schedule/shared/infra/repos/schedule_repository_mock'
+import e from 'cors'
+
+test('get schedules by event usecase', async () => {
+  const repo = new ScheduleRepositoryMock()
+  const usecase = new GetSchedulesByEventUsecase(repo)
+  const schedules = await usecase.call('2')
+
+  expect(schedules.length).toBe(3)
+  expect(schedules[0].id).toBe('77f361af-7e88-409b-92c0-cdeae2f19399')
+  expect(schedules[0].eventId).toBe('2')
+  expect(schedules[0].time).toBe(1632940200000)
+  expect(schedules[0].name).toBe('Sakamoto')
+})

--- a/back/tests/schedule/modules/post_schedule/post_schedule_controller.test.ts
+++ b/back/tests/schedule/modules/post_schedule/post_schedule_controller.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, test } from 'vitest'
+
+import { HttpRequest } from '../../../../src/shared/domain/helpers/http/http_request'
+import { HTTP_STATUS_CODE } from '../../../../src/shared/domain/helpers/http/http_status_code'
+import { ScheduleRepositoryMock } from '../../../../src/schedule/shared/infra/repos/schedule_repository_mock'
+import { PostScheduleUsecase } from '../../../../src/schedule/modules/post_schedule/post_schedule_usecase'
+import { PostScheduleController } from '../../../../src/schedule/modules/post_schedule/post_schedule_controller'
+
+test('post schedule controller created', async () => {
+  const repo = new ScheduleRepositoryMock()
+  const usecase = new PostScheduleUsecase(repo)
+  const controller = new PostScheduleController(usecase)
+
+  const request = new HttpRequest('post', {
+    eventId: '1',
+    time: 1632940200000,
+    name: 'Soller'
+  })
+
+  const response = await controller.call(request)
+  expect(response.status).toBe(HTTP_STATUS_CODE.CREATED)
+  expect(response.message).toBe('schedule created')
+  expect(response.data).toBeInstanceOf(Object)
+})
+
+describe('post schedule controller body', () => {
+  it('should return BAD REQUEST if body is missing', async () => {
+    const repo = new ScheduleRepositoryMock()
+    const usecase = new PostScheduleUsecase(repo)
+    const controller = new PostScheduleController(usecase)
+    const request = new HttpRequest('post', {} as any)
+    const response = await controller.call(request)
+    expect(response.status).toBe(HTTP_STATUS_CODE.BAD_REQUEST)
+    expect(response.message).toBe('missing body')
+    expect(response.data).toBe(undefined)
+  })
+
+  it('should return BAD REQUEST if eventId is missing', async () => {
+    const repo = new ScheduleRepositoryMock()
+    const usecase = new PostScheduleUsecase(repo)
+    const controller = new PostScheduleController(usecase)
+    const request = new HttpRequest('post', {
+      eventId: '',
+      time: 1632940200000,
+      name: 'Soller'
+    })
+    const response = await controller.call(request)
+    expect(response.status).toBe(HTTP_STATUS_CODE.BAD_REQUEST)
+    expect(response.message).toBe('missing eventId')
+    expect(response.data).toBe(undefined)
+  })
+
+  it('should return BAD REQUEST if name is missing', async () => {
+    const repo = new ScheduleRepositoryMock()
+    const usecase = new PostScheduleUsecase(repo)
+    const controller = new PostScheduleController(usecase)
+    const request = new HttpRequest('post', {
+      eventId: '1',
+      time: 1632940200000,
+      name: ''
+    })
+    const response = await controller.call(request)
+    expect(response.status).toBe(HTTP_STATUS_CODE.BAD_REQUEST)
+    expect(response.message).toBe('missing name')
+    expect(response.data).toBe(undefined)
+  })
+
+  it('should return BAD REQUEST if time is missing', async () => {
+    const repo = new ScheduleRepositoryMock()
+    const usecase = new PostScheduleUsecase(repo)
+    const controller = new PostScheduleController(usecase)
+    const request = new HttpRequest('post', {
+      eventId: '1',
+      time: 0,
+      name: 'Soller'
+    })
+    const response = await controller.call(request)
+    expect(response.status).toBe(HTTP_STATUS_CODE.BAD_REQUEST)
+    expect(response.message).toBe('missing time')
+    expect(response.data).toBe(undefined)
+  })
+})

--- a/back/tests/schedule/modules/post_schedule/post_schedule_presenter.test.ts
+++ b/back/tests/schedule/modules/post_schedule/post_schedule_presenter.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, test } from 'vitest'
+
+import { HttpRequest } from '../../../../src/shared/domain/helpers/http/http_request'
+import { HTTP_STATUS_CODE } from '../../../../src/shared/domain/helpers/http/http_status_code'
+import { ScheduleRepositoryMock } from '../../../../src/schedule/shared/infra/repos/schedule_repository_mock'
+import { PostSchedulePresenter } from '../../../../src/schedule/modules/post_schedule/post_schedule_presenter'
+
+test('post schedule presenter created', async () => {
+  const repo = new ScheduleRepositoryMock()
+  const presenter = new PostSchedulePresenter()
+  const request = new HttpRequest('post', {
+    eventId: '1',
+    time: 1632940200000,
+    name: 'Soller'
+  })
+  const response = await presenter.call(request)
+
+  const scheduleExpect = {
+    // cant use id because it is generated
+    event_id: '1',
+    time: 1632940200000,
+    name: 'Soller'
+  }
+  expect(response.status).toBe(HTTP_STATUS_CODE.CREATED)
+  expect(response.message).toBe('schedule created')
+  expect(response.data).contain(scheduleExpect)
+})

--- a/back/tests/schedule/modules/post_schedule/post_schedule_usecase.test.ts
+++ b/back/tests/schedule/modules/post_schedule/post_schedule_usecase.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from 'vitest'
+import { ScheduleRepositoryMock } from '../../../../src/schedule/shared/infra/repos/schedule_repository_mock'
+import { PostScheduleUsecase } from '../../../../src/schedule/modules/post_schedule/post_schedule_usecase'
+import { Schedule } from '../../../../src/shared/domain/entities/schedule'
+
+test('post schedule usecase created', async () => {
+  const repo = new ScheduleRepositoryMock()
+  const usecase = new PostScheduleUsecase(repo)
+
+  const schedule = await usecase.call(
+    '1',
+    1632940200000, // 1632940200000 = 29/09/2021 18:30:00 (GMT-3)
+    'Soller'
+  )
+
+  expect(schedule).toBeInstanceOf(Schedule)
+  expect(schedule?.id.length).toBe(36)
+  expect(schedule?.eventId).toBe('1')
+  expect(schedule?.time).toBe(1632940200000)
+  expect(schedule?.name).toBe('Soller')
+})

--- a/back/tests/schedule/shared/infra/repos/schedule_repository_mock.test.ts
+++ b/back/tests/schedule/shared/infra/repos/schedule_repository_mock.test.ts
@@ -12,6 +12,7 @@ test('test create schedule', async () => {
   const repo = new ScheduleRepositoryMock()
   const lenBefore: number = ScheduleRepositoryMock.schedules.length
   const schedule = await repo.createSchedule({
+    id: '3bdea174-7ae8-474b-a649-93be4620bba6',
     eventId: '2',
     time: 1632942000000,
     name: 'João'

--- a/back/tests/schedule/shared/infra/repos/schedule_repository_mock.test.ts
+++ b/back/tests/schedule/shared/infra/repos/schedule_repository_mock.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, test } from 'vitest'
+
+import { ScheduleRepositoryMock } from '../../../../../src/schedule/shared/infra/repos/schedule_repository_mock'
+
+test('test get schedules by event id', async () => {
+  const repo = new ScheduleRepositoryMock()
+  const schedules = await repo.getSchedulesByEventId('2')
+  expect(schedules.length).toBe(3)
+})
+
+test('test create schedule', async () => {
+  const repo = new ScheduleRepositoryMock()
+  const lenBefore: number = ScheduleRepositoryMock.schedules.length
+  const schedule = await repo.createSchedule({
+    eventId: '2',
+    time: 1632942000000,
+    name: 'João'
+  })
+  const lenAfter: number = ScheduleRepositoryMock.schedules.length
+  expect(schedule.id).not.toBeUndefined()
+  expect(lenAfter).toBe(lenBefore + 1)
+})
+
+test('test delete schedule', async () => {
+  const repo = new ScheduleRepositoryMock()
+  const lenBefore: number = ScheduleRepositoryMock.schedules.length
+  const schedule = await repo.deleteSchedule(
+    'ba096c65-bca0-4242-98b1-383e85f6e930'
+  )
+  const lenAfter: number = ScheduleRepositoryMock.schedules.length
+  expect(schedule.id).toBe('ba096c65-bca0-4242-98b1-383e85f6e930')
+  expect(lenAfter).toBe(lenBefore - 1)
+})

--- a/back/tests/shared/domain/entities/schedule.test.ts
+++ b/back/tests/shared/domain/entities/schedule.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from 'vitest'
+
+import { Schedule } from '../../../../src/shared/domain/entities/schedule'
+
+test('Test schedule', () => {
+  const schedule = new Schedule('1', '1', 1632950400000, 'Schedule Name')
+
+  expect(schedule.id).toBe('1')
+  expect(schedule.eventId).toBe('1')
+  expect(schedule.time).toBe(1632950400000)
+  expect(schedule.name).toBe('Schedule Name')
+})


### PR DESCRIPTION
Este PR implementa o segundo mss (schedule-mss).

Aqui possuimos tem funcionalidades primordiais para o sistema:
- get schedules by event
- post schedule
- delete schedule

Já haviamos criado um esqueleto do frontend (configuração, pastas, arquivos, estruturas, etc). Trabalharemos nas próximas semanas com o UX/UI para realmente implementar as features criadas pelo backend.

É necessário discutir mais com o grupo sobre como serão implementadas as ligações entre mss bem como a "autenticação" entre usuários. Deixaremos para próxima entrega a correção dessas funcionalidades.
Este PR também adiciona um CI de teste do backend 🤠
